### PR TITLE
Adding Chimayo.Ssis.CommandLine.config to NuGet package

### DIFF
--- a/Chimayo.Ssis.paket.template
+++ b/Chimayo.Ssis.paket.template
@@ -69,6 +69,7 @@ files
     src/Chimayo.Ssis.Reader2012/bin/Release/Chimayo.Ssis.Reader2012.pdb ==> tools
     src/Chimayo.Ssis.Reader2012/bin/Release/Chimayo.Ssis.Reader2012.xml ==> tools
 	src/Chimayo.Ssis.CommandLine/bin/Release/Chimayo.Ssis.CommandLine.exe ==> tools
+	src/Chimayo.Ssis.CommandLine/bin/Release/Chimayo.Ssis.CommandLine.exe.config ==> tools
     src/Chimayo.Ssis.CommandLine/bin/Release/Chimayo.Ssis.CommandLine.pdb ==> tools
     src/Chimayo.Ssis.CommandLine/bin/Release/Chimayo.Ssis.CommandLine.xml ==> tools
 	packages/FParsec/lib/net40-client/* ==> tools


### PR DESCRIPTION
Correction for missing config file in tools folder of NuGet package.
